### PR TITLE
Fix Generate Calendar workflow

### DIFF
--- a/.github/workflows/generate-calendar.yml
+++ b/.github/workflows/generate-calendar.yml
@@ -1,17 +1,15 @@
 name: Generate Calendar
 
 on:
-  pull_request:
+  push:
     branches: [ master, main ]
-    # Only run when posts or calendar generator files change
     paths:
       - '_posts/**'
       - 'scripts/calendar_generator/**'
   workflow_dispatch:  # Allow manual triggering
 
 permissions:
-  contents: write  # Allow writing to the repository
-  pull-requests: read  # Allow reading PR information
+  contents: write
 
 jobs:
   generate-calendar:
@@ -22,8 +20,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        # Checkout the PR branch, not master
-        ref: ${{ github.head_ref }}
     
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -31,19 +27,12 @@ jobs:
         python-version: '3.11'
         cache: 'pip'
     
-    - name: Install dependencies
+    - name: Generate and copy calendar
       run: |
         cd scripts/calendar_generator
         pip install -r requirements.txt
-    
-    - name: Generate calendar
-      run: |
-        cd scripts/calendar_generator
         python generate_calendar.py
-        
-    - name: Copy calendar to site root
-      run: |
-        cp scripts/calendar_generator/dotnet-regensburg.ics ./calendar.ics
+        cp calendar.ics ../../calendar.ics
         
     - name: Check for changes
       id: verify-changed-files
@@ -54,11 +43,11 @@ jobs:
           echo "changed=false" >> $GITHUB_OUTPUT
         fi
     
-    - name: Commit calendar updates to PR
+    - name: Commit calendar updates
       if: steps.verify-changed-files.outputs.changed == 'true'
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git add calendar.ics scripts/calendar_generator/dotnet-regensburg.ics
-        git commit -m "Update calendar file based on recent changes"
-        git push origin ${{ github.head_ref }}
+        git add calendar.ics
+        git commit -m "Update calendar file based on recent changes [skip ci]"
+        git push

--- a/_includes/talks.html
+++ b/_includes/talks.html
@@ -63,7 +63,7 @@
                     </a>
                 </div>
                 <p class="small text-muted" style="margin-top: 10px;">
-                    Der "Kalender abonnieren" Button öffnet Ihre Standard-Kalender-App (Outlook, Apple Kalender, etc.)
+                    Der "Kalender abonnieren" Button öffnet Ihre Standard-Kalender-App (Google Calendar, Apple Kalender, etc.)
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Updated the generate calendar workflow to run on new pushes to the master branch (not only on PRs like before).
Also fixed some typos / wrong paths ~~- which is why it will fail on this PR~~ (nevermind, it won't run when the posts / scripts don't change) 😄 

> After this PR has been merged, the Action has to be run **manually** once - afterwards it runs automatically on new pushes.

Also, I changed the text on the webpage to not mention Outlook anymore, as the new Outlook has some issues with [webcals](https://learn.microsoft.com/en-us/answers/questions/4646333/cannot-import-ics-file-into-outlook-(new)-app).